### PR TITLE
feat(UI): Add the platform modules hook to ui-context

### DIFF
--- a/packages/ui-context/src/UserContext.ts
+++ b/packages/ui-context/src/UserContext.ts
@@ -36,7 +36,7 @@ const defaultDowntime = {
 
 const defaultRefreshInterval = 15;
 
-const defaultPlatformModules = {
+export const defaultPlatformModules = {
   modules: {},
   web: {
     fix: '0',

--- a/packages/ui-context/src/UserContext.ts
+++ b/packages/ui-context/src/UserContext.ts
@@ -36,10 +36,22 @@ const defaultDowntime = {
 
 const defaultRefreshInterval = 15;
 
+const defaultPlatformModules = {
+  modules: {},
+  web: {
+    fix: '0',
+    license: null,
+    major: '21',
+    minor: '10',
+    version: '21.10.0',
+  },
+};
+
 const defaultContext: UserContext = {
   ...defaultUser,
   acl: defaultAcl,
   downtime: defaultDowntime,
+  platformModules: defaultPlatformModules,
   refreshInterval: defaultRefreshInterval,
 };
 

--- a/packages/ui-context/src/index.ts
+++ b/packages/ui-context/src/index.ts
@@ -3,5 +3,13 @@ export { default as useUser } from './useUser';
 export { default as useAcl } from './useAcl';
 export { default as useDowntime } from './useDowntime';
 export { default as useRefreshInterval } from './useRefreshInterval';
+export { default as usePlatformModules } from './usePlatformModules';
 
-export type { User, UserContext, ActionAcl, Actions, Downtime } from './types';
+export type {
+  User,
+  UserContext,
+  ActionAcl,
+  Actions,
+  Downtime,
+  PlatformModules,
+} from './types';

--- a/packages/ui-context/src/types.ts
+++ b/packages/ui-context/src/types.ts
@@ -31,3 +31,25 @@ interface Acl {
 export interface Downtime {
   default_duration: number;
 }
+interface ModuleLicense {
+  status: boolean;
+}
+
+interface Module {
+  fix: string;
+  license: ModuleLicense | null;
+  major: string;
+  minor: string;
+  version: string;
+}
+
+interface Modules {
+  'centreon-autodiscovery-server'?: Module;
+  'centreon-bam-server'?: Module;
+  'centreon-license-manager'?: Module;
+  'centreon-pp-manager'?: Module;
+}
+export interface PlatformModules {
+  modules: Modules;
+  web: Module;
+}

--- a/packages/ui-context/src/types.ts
+++ b/packages/ui-context/src/types.ts
@@ -8,6 +8,7 @@ export interface User {
 export type UserContext = {
   acl: Acl;
   downtime: Downtime;
+  platformModules: PlatformModules;
   refreshInterval: number;
 } & User;
 

--- a/packages/ui-context/src/usePlatformModules.ts
+++ b/packages/ui-context/src/usePlatformModules.ts
@@ -1,0 +1,19 @@
+import * as React from 'react';
+
+import { PlatformModules } from './types';
+
+interface PlatformModulesState {
+  platformModules: PlatformModules | undefined;
+  setPlatformModules: React.Dispatch<
+    React.SetStateAction<PlatformModules | undefined>
+  >;
+}
+
+const usePlatformModules = (): PlatformModulesState => {
+  const [platformModules, setPlatformModules] =
+    React.useState<PlatformModules | undefined>(undefined);
+
+  return { platformModules, setPlatformModules };
+};
+
+export default usePlatformModules;

--- a/packages/ui-context/src/usePlatformModules.ts
+++ b/packages/ui-context/src/usePlatformModules.ts
@@ -1,17 +1,17 @@
 import * as React from 'react';
 
 import { PlatformModules } from './types';
+import { defaultPlatformModules } from './UserContext';
 
 interface PlatformModulesState {
-  platformModules: PlatformModules | undefined;
-  setPlatformModules: React.Dispatch<
-    React.SetStateAction<PlatformModules | undefined>
-  >;
+  platformModules: PlatformModules;
+  setPlatformModules: React.Dispatch<React.SetStateAction<PlatformModules>>;
 }
 
 const usePlatformModules = (): PlatformModulesState => {
-  const [platformModules, setPlatformModules] =
-    React.useState<PlatformModules | undefined>(undefined);
+  const [platformModules, setPlatformModules] = React.useState<PlatformModules>(
+    defaultPlatformModules,
+  );
 
   return { platformModules, setPlatformModules };
 };


### PR DESCRIPTION
This adds the platform modules hook to ui-context to share modules versions and available licenses to Centreon Web and his modules