### PR TITLE
enh(Centreon UI/Listing): Provide a way to disable columns in the selection

### DIFF
--- a/packages/centreon-ui/src/InputField/Select/IconPopover/index.tsx
+++ b/packages/centreon-ui/src/InputField/Select/IconPopover/index.tsx
@@ -115,6 +115,7 @@ const IconPopoverMultiAutocomplete = ({
               const { id, name } = option;
               return (
                 <MenuItem
+                  disabled={option.disabled || false}
                   key={id}
                   value={name}
                   onClick={() => unSelect(option)}

--- a/packages/centreon-ui/src/InputField/Select/index.tsx
+++ b/packages/centreon-ui/src/InputField/Select/index.tsx
@@ -34,6 +34,7 @@ const useStyles = makeStyles((theme: Theme) => ({
 export interface SelectEntry {
   color?: string;
   createOption?: string;
+  disabled?: boolean;
   id: number | string;
   inputValue?: string;
   name: string;

--- a/packages/centreon-ui/src/Listing/ActionBar/ColumnMultiSelect.tsx
+++ b/packages/centreon-ui/src/Listing/ActionBar/ColumnMultiSelect.tsx
@@ -17,7 +17,8 @@ type Props = Pick<
 >;
 
 const toSelectEntries = (columns: Array<Column>): Array<SelectEntry> => {
-  return columns.map(({ id, label }) => ({
+  return columns.map(({ id, label, disabled }) => ({
+    disabled,
     id,
     name: label,
   }));

--- a/packages/centreon-ui/src/Listing/index.stories.tsx
+++ b/packages/centreon-ui/src/Listing/index.stories.tsx
@@ -131,7 +131,35 @@ export const withActions = (): JSX.Element => <Story actions={actions} />;
 
 export const withoutCheckboxes = (): JSX.Element => <Story checkable={false} />;
 
-const ListingWithSortableColumns = (): JSX.Element => {
+const editableColumns = [
+  {
+    getFormattedString: ({ name }): string => name,
+    id: 'name',
+    label: 'Name',
+    type: ColumnType.string,
+  },
+  {
+    getFormattedString: ({ description }): string => description,
+    id: 'description',
+    label: 'Description',
+    type: ColumnType.string,
+  },
+  {
+    Component: ComponentColumn,
+    id: '#',
+    label: 'Custom',
+    type: ColumnType.component,
+  },
+  {
+    disabled: true,
+    getFormattedString: ({ name }): string => name,
+    id: 'disabled_name',
+    label: 'Disabled Name',
+    type: ColumnType.string,
+  },
+];
+
+const ListingWithEditableColumns = (): JSX.Element => {
   const defaultColumnIds = defaultColumns.map(prop('id'));
 
   const [selectedColumnIds, setSelectedColumnIds] =
@@ -147,7 +175,7 @@ const ListingWithSortableColumns = (): JSX.Element => {
         selectedColumnIds,
         sortable: true,
       }}
-      columns={defaultColumns}
+      columns={editableColumns}
       onResetColumns={resetColumns}
       onSelectColumns={setSelectedColumnIds}
     />
@@ -155,5 +183,5 @@ const ListingWithSortableColumns = (): JSX.Element => {
 };
 
 export const withEditableColumns = (): JSX.Element => (
-  <ListingWithSortableColumns />
+  <ListingWithEditableColumns />
 );

--- a/packages/centreon-ui/src/Listing/models.ts
+++ b/packages/centreon-ui/src/Listing/models.ts
@@ -9,6 +9,7 @@ export interface Column {
   clickable?: boolean;
   compact?: boolean;
   disablePadding?: boolean;
+  disabled?: boolean;
   getColSpan?: (isSelected) => number | undefined;
   getFormattedString?: (row) => string | null;
   getHiddenCondition?: (isSelected) => boolean;


### PR DESCRIPTION
This adds a `disabled` property to disable one or more columns in the columns selection
![Screenshot 2021-06-09 at 10 19 20](https://user-images.githubusercontent.com/12515407/121320934-e80f3280-c90d-11eb-90ff-5b8e10501902.png)
