### PR TITLE
enh(Config/Webpack): Fix cached build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,6 @@
         "babel-jest": "27.x",
         "babel-loader": "8.x",
         "babel-merge": "3.x",
-        "cache-loader": "4.x",
         "clean-webpack-plugin": "^3.x",
         "css-loader": "5.x",
         "eslint": "7.x",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
     "babel-jest": "27.x",
     "babel-loader": "8.x",
     "babel-merge": "3.x",
-    "cache-loader": "4.x",
     "clean-webpack-plugin": "^3.x",
     "css-loader": "5.x",
     "eslint": "7.x",

--- a/packages/frontend-config/webpack/base/index.js
+++ b/packages/frontend-config/webpack/base/index.js
@@ -3,13 +3,13 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const path = require('path');
 
 module.exports = {
+  cache: false,
   module: {
     rules: [
       {
         exclude: /node_modules(\\|\/)(?!(@centreon(\\|\/)centreon-frontend(\\|\/)packages(\\|\/)(ui-context|centreon-ui)))/,
         test: /\.(j|t)sx?$/,
         use: [
-          { loader: 'cache-loader' },
           'babel-loader',
           {
             loader: 'ts-loader',

--- a/packages/frontend-config/webpack/patch/dev.js
+++ b/packages/frontend-config/webpack/patch/dev.js
@@ -1,9 +1,9 @@
 module.exports = {
+  cache: true,
   devtool: 'eval-cheap-module-source-map',
-
   optimization: {
     splitChunks: false,
-  },  
+  },
   output: {
     filename: '[name].js',
   },


### PR DESCRIPTION
There is an issue about cache-loader that uses the cached dev build for a production build. Furthermore, this library is archived: https://github.com/webpack-contrib/cache-loader
We use the builtin webpack cache. 