### PR TITLE
fix(UI): Add callback when closing popup filter

### DIFF
--- a/packages/centreon-ui/src/PopoverMenu/index.tsx
+++ b/packages/centreon-ui/src/PopoverMenu/index.tsx
@@ -51,13 +51,13 @@ const PopoverMenu = ({
     if (isClosedByInputClick) {
       return;
     }
+    onClose?.();
     setAnchorEl(undefined);
   };
 
   const toggle = (event): void => {
     if (isOpen) {
       close();
-      onClose?.();
 
       return;
     }


### PR DESCRIPTION
Add callback when closing popup filter by clicking anywhere than the icon menu