### PR TITLE
fix(ui): Add missing type on function getErrorMessage

### DIFF
--- a/packages/centreon-ui/src/api/useRequest/index.ts
+++ b/packages/centreon-ui/src/api/useRequest/index.ts
@@ -14,7 +14,7 @@ const log = anylogger('API Request');
 export interface RequestParams<TResult> {
   decoder?: JsonDecoder.Decoder<TResult>;
   defaultFailureMessage?: string;
-  getErrorMessage?: (error) => string;
+  getErrorMessage?: (error) => string | ((props) => JSX.Element);
   request: (token) => (params?) => Promise<TResult>;
 }
 


### PR DESCRIPTION
# Description

Add missing type on function getErrorMessage

# issues

```
Type '(obj: any) => string | (() => Element)' is not assignable to type '(error: any) => string'.
  Type 'string | (() => Element)' is not assignable to type 'string'.
    Type '() => JSX.Element' is not assignable to type 'string'.ts(2322)
index.ts(17, 3): The expected type comes from property 'getErrorMessage' which is declared here on type 'RequestParams<ResourceListing>'
```

# Fixe

Add missing type on function getErrorMessage
