### PR TITLE
chore(Config/Webpack): Clean up webpack Module patch config

### DIFF
--- a/packages/frontend-config/webpack/patch/module.js
+++ b/packages/frontend-config/webpack/patch/module.js
@@ -7,39 +7,7 @@ module.exports = ({ assetPublicPath, outputPath }) => ({
     react: 'React',
     'react-dom': 'ReactDOM',
     'react-i18next': 'ReactI18Next',
-    'react-redux': 'ReactRedux',
-    'react-redux-i18n': 'ReactReduxI18n',
     'react-router-dom': 'ReactRouterDom',
-  },
-  module: {
-    rules: [
-      {
-        test: /\.(c|sa|sc)ss$/,
-        use: [
-          'style-loader',
-          { loader: 'css-loader', options: { modules: true } },
-          {
-            loader: 'sass-loader',
-            options: {
-              sassOptions: {
-                modules: true,
-              },
-            },
-          },
-        ],
-      },
-      {
-        test: /\.(png|svg|jpg|gif|off|woff|woff2|eot|ttf|otf)$/,
-        use: [
-          {
-            loader: 'file-loader',
-            options: {
-              publicPath: assetPublicPath,
-            },
-          },
-        ],
-      },
-    ],
   },
   output: {
     library: '[chunkhash:8]',
@@ -48,10 +16,7 @@ module.exports = ({ assetPublicPath, outputPath }) => ({
   },
   plugins: [
     new CleanWebpackPlugin({
-      cleanOnceBeforeBuildPatterns: [
-        `${outputPath}/**/*.js`,
-        `${outputPath}/**/*.css`,
-      ],
+      cleanOnceBeforeBuildPatterns: [`${outputPath}/**/*.js`],
       dangerouslyAllowCleanPatternsOutsideProject: true,
       dry: false,
     }),


### PR DESCRIPTION
As we no longer have SCSS or images files to handle on modules, we can remove SASS and images support from the Module patch