### PR TITLE
enh(config): Remove scope from centreon-frontend path

### DIFF
--- a/packages/frontend-config/tsconfig/index.json
+++ b/packages/frontend-config/tsconfig/index.json
@@ -2,8 +2,8 @@
   "extends": "./base",
   "compilerOptions": {
     "paths": {
-      "@centreon/ui": ["./node_modules/@centreon/centreon-frontend/packages/centreon-ui"],
-      "@centreon/ui-context": ["./node_modules/@centreon/centreon-frontend/packages/ui-context"]
+      "@centreon/ui": ["./node_modules/centreon-frontend/packages/centreon-ui"],
+      "@centreon/ui-context": ["./node_modules/centreon-frontend/packages/ui-context"]
     }
   }
 }

--- a/packages/frontend-config/webpack/base/index.js
+++ b/packages/frontend-config/webpack/base/index.js
@@ -12,7 +12,7 @@ module.exports = {
       },
       {
         exclude:
-          /node_modules(\\|\/)(?!(@centreon(\\|\/)centreon-frontend(\\|\/)packages(\\|\/)(ui-context|centreon-ui)))/,
+          /node_modules(\\|\/)(?!(centreon-frontend(\\|\/)packages(\\|\/)(ui-context|centreon-ui)))/,
         test: /\.(j|t)sx?$/,
         use: [
           'babel-loader',
@@ -58,10 +58,10 @@ module.exports = {
   resolve: {
     alias: {
       '@centreon/ui': path.resolve(
-        './node_modules/@centreon/centreon-frontend/packages/centreon-ui',
+        './node_modules/centreon-frontend/packages/centreon-ui',
       ),
       '@centreon/ui-context': path.resolve(
-        './node_modules/@centreon/centreon-frontend/packages/ui-context',
+        './node_modules/centreon-frontend/packages/ui-context',
       ),
       react: path.resolve('./node_modules/react'),
     },


### PR DESCRIPTION
The scoped package name forces the developer to have an additional @centreon directory above centreon-frontend in order for npm link to work properly