### PR TITLE
enh(license-manager token): delete the background color used in wizard

### DIFF
--- a/packages/centreon-ui/src/Wizard/index.tsx
+++ b/packages/centreon-ui/src/Wizard/index.tsx
@@ -12,9 +12,8 @@ import { WizardProps } from './models';
 import Stepper from './Stepper';
 import WizardContent from './WizardContent';
 
-const useStyles = makeStyles((theme) => ({
+const useStyles = makeStyles(() => ({
   dialogContent: {
-    backgroundColor: theme.palette.grey[100],
     display: 'flex',
     padding: 0,
   },


### PR DESCRIPTION
when working in centreon-license-manager to add dark mode
the add token dialog had a gray background color even in dark mode, so it has been removed from frontend-centreon Wizard