### PR TITLE
enh(Wizard): change the background color of wizard components

### DIFF
--- a/packages/centreon-ui/src/Wizard/Stepper.tsx
+++ b/packages/centreon-ui/src/Wizard/Stepper.tsx
@@ -24,7 +24,7 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   stepper: {
-    backgroundColor: theme.palette.grey[200],
+    // backgroundColor: theme.palette.grey[200],
     padding: theme.spacing(2),
   },
 }));

--- a/packages/centreon-ui/src/Wizard/Stepper.tsx
+++ b/packages/centreon-ui/src/Wizard/Stepper.tsx
@@ -24,7 +24,6 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   stepper: {
-    // backgroundColor: theme.palette.grey[200],
     padding: theme.spacing(2),
   },
 }));


### PR DESCRIPTION

# Wizzard steppers 🧙  
![image](https://user-images.githubusercontent.com/97686091/155717252-d0e91908-b62f-4232-9943-f2e825a5be7a.png)

the code is commented out now until we choose a better color for the stepper background color