### PR TITLE
enh(SortableItems): Improve dnd keyboard navigation

### DIFF
--- a/packages/centreon-ui/src/SortableItems/index.stories.tsx
+++ b/packages/centreon-ui/src/SortableItems/index.stories.tsx
@@ -106,6 +106,7 @@ const Content = ({
       {...attributes}
       className={classes.content}
       ref={itemRef}
+      tabIndex={0}
     >
       <Typography>{name as string}</Typography>
     </Paper>

--- a/packages/centreon-ui/src/SortableItems/index.tsx
+++ b/packages/centreon-ui/src/SortableItems/index.tsx
@@ -111,6 +111,19 @@ const SortableItems = <T extends { [propertyToFilterItemsOn]: string }>({
     useSensor(PointerSensor),
     useSensor(KeyboardSensor, {
       coordinateGetter: sortableKeyboardCoordinates,
+      keyboardCodes: {
+        cancel: ['Escape'],
+        end: ['Space', 'Enter'],
+        start: [
+          'ArrowUp',
+          'ArrowDown',
+          'ArrowLeft',
+          'ArrowRight',
+          'Enter',
+          'Space',
+        ],
+      },
+      scrollBehavior: 'smooth',
     }),
   );
   const theme = useTheme();


### PR DESCRIPTION
This improves drag and drop keyboard navigation by supporting Arrow keys to start the navigation (in addition to the "Enter" and "Space" keys as recommended by dnd-kit) 