### PR TITLE
fix : MON-12744-date-userMenu

### DIFF
--- a/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
+++ b/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
@@ -33,7 +33,7 @@ const useLocaleDateTimeFormat = (): LocaleDateTimeFormat => {
     const normalizedLocale = locale.substring(0, 2);
 
     const timezoneDate = dayjs(
-      new Date().toLocaleString('en', { timeZone: timezone }),
+      new Date(date).toLocaleString('en', { timeZone: timezone }),
     ).locale(normalizedLocale);
 
     return timezoneDate.format(formatString);

--- a/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
+++ b/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
@@ -29,7 +29,7 @@ const dateTimeFormat = `${dateFormat} ${timeFormat}`;
 const useLocaleDateTimeFormat = (): LocaleDateTimeFormat => {
   const { locale, timezone } = useAtomValue(userAtom);
 
-  const format = ({ formatString }: FormatParameters): string => {
+  const format = ({ date, formatString }: FormatParameters): string => {
     const normalizedLocale = locale.substring(0, 2);
 
     const timezoneDate = dayjs(

--- a/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
+++ b/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
@@ -35,7 +35,7 @@ const useLocaleDateTimeFormat = (): LocaleDateTimeFormat => {
 
     const timezoneDate = equals(timezone, 'UTC')
       ? dayjs(date).locale(normalizedLocale).utc()
-      : dayjs(date).locale(normalizedLocale).tz(timezone);
+      : dayjs(date).tz(timezone).locale(normalizedLocale);
 
     return timezoneDate.format(formatString);
   };

--- a/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
+++ b/packages/centreon-ui/src/utils/useLocaleDateTimeFormat/index.ts
@@ -2,7 +2,6 @@ import dayjs from 'dayjs';
 import 'dayjs/plugin/timezone';
 import 'dayjs/plugin/utc';
 import humanizeDuration from 'humanize-duration';
-import { equals } from 'ramda';
 import { useAtomValue } from 'jotai/utils';
 
 import { userAtom } from '@centreon/ui-context';
@@ -30,12 +29,12 @@ const dateTimeFormat = `${dateFormat} ${timeFormat}`;
 const useLocaleDateTimeFormat = (): LocaleDateTimeFormat => {
   const { locale, timezone } = useAtomValue(userAtom);
 
-  const format = ({ date, formatString }: FormatParameters): string => {
+  const format = ({ formatString }: FormatParameters): string => {
     const normalizedLocale = locale.substring(0, 2);
 
-    const timezoneDate = equals(timezone, 'UTC')
-      ? dayjs(date).locale(normalizedLocale).utc()
-      : dayjs(date).tz(timezone).locale(normalizedLocale);
+    const timezoneDate = dayjs(
+      new Date().toLocaleString('en', { timeZone: timezone }),
+    ).locale(normalizedLocale);
 
     return timezoneDate.format(formatString);
   };


### PR DESCRIPTION
fix date/Time on the top-right dosent respect user configuration
**before** : 
![timeBefore](https://user-images.githubusercontent.com/97687698/163401205-58500a9f-d24a-4031-8024-e8b37eedfd0d.png)

**after** :
![timeAfetr](https://user-images.githubusercontent.com/97687698/163401271-e38c92f6-fc61-43e8-bc52-a82c66fa3cff.png)

